### PR TITLE
Update tooltip_c.lua

### DIFF
--- a/ElvUI_SLE/options/tooltip_c.lua
+++ b/ElvUI_SLE/options/tooltip_c.lua
@@ -83,7 +83,7 @@ local function configTable()
 							ep = { order = -42, type = 'toggle', name = SLE:GetMapInfo(1512, 'name') },
 							nzoth = { order = -41, type = 'toggle', name = SLE:GetMapInfo(1580, 'name') },
 							nathria = { order = -40, type = 'toggle', name = SLE:GetMapInfo(1735, 'name') },
-							sod = { order = -39, type = 'toggle', name = 'Sanctum of Domination' },
+							sod = { order = -39, type = 'toggle', name = SLE:GetMapInfo(1998, 'name') },
 						},
 					},
 				},


### PR DESCRIPTION
So it will be more correct ?
At least now the name of the raid is displayed in Russian.
In other languages ​​will it be displayed accordingly ?!