### PR TITLE
Enable moving StaticPopups temporarily

### DIFF
--- a/ElvUI_SLE/modules/blizzard.lua
+++ b/ElvUI_SLE/modules/blizzard.lua
@@ -40,6 +40,10 @@ B.Frames = {
 	SpellBookFrame = true,
 	SplashFrame = true,
 	StackSplitFrame = true,
+	StaticPopup1 = true,
+	StaticPopup2 = true,
+	StaticPopup3 = true,
+	StaticPopup4 = true,
 	TabardFrame = true,
 	TaxiFrame = true,
 	TimeManagerFrame = true,
@@ -53,6 +57,10 @@ B.TempOnly = {
 	BonusRollFrame = true,
 	BonusRollLootWonFrame = true,
 	BonusRollMoneyWonFrame = true,
+	StaticPopup1 = true,
+	StaticPopup2 = true,
+	StaticPopup3 = true,
+	StaticPopup4 = true,
 }
 
 --Blizz addons that load later


### PR DESCRIPTION
StaticPopups create errors if we try to remember their location, but can be movable temporarily without causing the same error. This is a fix for issue https://github.com/Shadow-and-Light/shadow-and-light/issues/77